### PR TITLE
Fix typo on :require example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ```clojure
 [reagent "0.7.0"]
-[darkelaf/form "0.1.0"]
+[darkleaf/form "0.1.0"]
 ```
 
 # Usage example


### PR DESCRIPTION
I honestly thought it was the correct name, following the steps of [*dakrone*](https://github.com/dakrone) 😆 